### PR TITLE
Added Group `config`

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1806,8 +1806,6 @@ Opens the config file for editing in $EDITOR
         Transfer-Encoding: chunked
         ```
 
-    + Attributes
-
     + Body
 
         ```

--- a/apiary.apib
+++ b/apiary.apib
@@ -715,6 +715,8 @@ Retrieve information on a raw ipfs block.
         Content-Type: text/plain; charset=utf-8
         ```
 
+    + Attributes (string)
+
     + Body
 
         ```
@@ -1504,28 +1506,28 @@ Retrieves the object named by <ipfs-or-ipns-path> and outputs the data it contai
 
 # Group config
 
-## config [GET /config{?arg1,arg2}{&bool,json}]
+## config [POST /config{?arg1,arg2}{&bool,json}]
 
 'ipfs config' controls configuration variables. It works
-much like `git config`. The configuration values are stored in a config
+much like 'git config'. The configuration values are stored in a config
 file inside your IPFS repository.
 
 + Parameters
-    + arg1: "Datastore.Path" (string, required) - The key of the config entry
-    + arg2: "~/.ipfs/datastore" (string, required) - The value to set the config entry to
-    + bool (boolean, optional) - Set a boolean
-    + json (boolean, optional) - Parse stringified JSON
+    + arg1: "Datastore.Path" (string, required) - The key of the config entry.
+    + arg2: "~/.ipfs/datastore" (string, required) - The value to set the config entry to.
+    + bool (boolean, optional) - Set a boolean.
+    + json (boolean, optional) - Parse stringified JSON.
 
 + Request Without Arguments
 
     #### curl
 
-        curl -i http://localhost:5001/api/v0/config
+        curl -i -X POST "http://localhost:5001/api/v0/config"
 
     + Body
 
         ```
-        curl -i http://localhost:5001/api/v0/config
+        curl -i -X POST "http://localhost:5001/api/v0/config"
         ```
 
 + Response 400
@@ -1548,15 +1550,15 @@ file inside your IPFS repository.
 
     #### curl
 
-        curl -i http://localhost:5001/api/v0/config?arg=kitten
+        curl -i -X POST "http://localhost:5001/api/v0/config?arg=kitten"
 
     + Body
 
         ```
-        curl -i http://localhost:5001/api/v0/config?arg=kitten
+        curl -i -X POST "http://localhost:5001/api/v0/config?arg=kitten"
         ```
 
-+ Response 500 (application/json)
++ Response 500
 
     + Headers
 
@@ -1587,12 +1589,12 @@ file inside your IPFS repository.
 
     #### curl
 
-        curl -i http://localhost:5001/api/v0/config?arg=API.HTTPHeaders
+        curl -i -X POST "http://localhost:5001/api/v0/config?arg=API.HTTPHeaders"
 
     + Body
 
         ```
-        curl -i http://localhost:5001/api/v0/config?arg=API.HTTPHeaders
+        curl -i -X POST "http://localhost:5001/api/v0/config?arg=API.HTTPHeaders"
         ```
 
 + Response 200
@@ -1611,7 +1613,7 @@ file inside your IPFS repository.
 
     + Attributes (object)
         + `Key`: "Datastore" (string)
-        + `Value`: null (object, nullable) - The config entry
+        + `Value`: null (object, nullable) - The config entry.
 
     + Body
 
@@ -1622,16 +1624,16 @@ file inside your IPFS repository.
         }
         ```
 
-+ Request As SubCommand
++ Request As Subcommand
 
     #### curl
 
-        curl -i http://localhost:5001/api/v0/config/API.HTTPHeaders
+        curl -i -X POST "http://localhost:5001/api/v0/config/API.HTTPHeaders"
 
     + Body
 
         ```
-        curl -i http://localhost:5001/api/v0/config/API.HTTPHeaders
+        curl -i -X POST "http://localhost:5001/api/v0/config/API.HTTPHeaders"
         ```
 
 + Response 200
@@ -1650,7 +1652,7 @@ file inside your IPFS repository.
 
     + Attributes (object)
         + `Key`: "Datastore" (string)
-        + `Value`: null (object, nullable) - The config entry
+        + `Value`: null (object, nullable) - The config entry.
 
     + Body
 
@@ -1661,16 +1663,16 @@ file inside your IPFS repository.
         }
         ```
 
-+ Request With POST
++ Request With Both Args
 
     #### curl
 
-        curl -i "http://localhost:5001/api/v0/config?arg=Datastore.Path&arg=kitten"
+        curl -i -X POST "http://localhost:5001/api/v0/config?arg=Datastore.Path&arg=kitten"
 
     + Body
 
         ```
-        curl -i "http://localhost:5001/api/v0/config?arg=Datastore.Path&arg=kitten"
+        curl -i -X POST "http://localhost:5001/api/v0/config?arg=Datastore.Path&arg=kitten"
         ```
 
 + Response 200
@@ -1699,16 +1701,16 @@ file inside your IPFS repository.
         }
         ```
 
-+ Request With POST and JSON Flag With Invalid JSON Argument
++ Request With Both Args and JSON Flag With Invalid JSON Argument
 
     #### curl
 
-        curl -i "http://localhost:5001/api/v0/config?arg=Datastore.Path&arg=kitten&json"
+        curl -i -X POST "http://localhost:5001/api/v0/config?arg=Datastore.Path&arg=kitten&json"
 
     + Body
 
         ```
-        curl -i "http://localhost:5001/api/v0/config?arg=Datastore.Path&arg=kitten&json"
+        curl -i -X POST "http://localhost:5001/api/v0/config?arg=Datastore.Path&arg=kitten&json"
         ```
 
 + Response 500
@@ -1737,16 +1739,16 @@ file inside your IPFS repository.
         }
         ```
 
-+ Request With POST and JSON Flag With Valid JSON Argument
++ Request With Both Args and JSON Flag With Valid JSON Argument
 
     #### curl
 
-        curl -i "http://localhost:5001/api/v0/config?arg=Datastore.Path&arg=\"kitten\"&json"
+        curl -i -X POST "http://localhost:5001/api/v0/config?arg=Datastore.Path&arg=\"kitten\"&json"
 
     + Body
 
         ```
-        curl -i "http://localhost:5001/api/v0/config?arg=Datastore.Path&arg=\"kitten\"&json"
+        curl -i -X POST "http://localhost:5001/api/v0/config?arg=Datastore.Path&arg=\"kitten\"&json"
         ```
 
 + Response 200
@@ -1782,12 +1784,12 @@ Opens the config file for editing in $EDITOR
 
     ### curl
 
-        curl -i http://localhost:5001/api/v0/config/edit
+        curl -i "http://localhost:5001/api/v0/config/edit"
 
     + Body
 
         ```
-        curl -i http://localhost:5001/api/v0/config/edit
+        curl -i "http://localhost:5001/api/v0/config/edit"
         ```
 
 + Response 200
@@ -1811,7 +1813,7 @@ Opens the config file for editing in $EDITOR
         ```
         ```
 
-## replace [GET /config/replace{?arg}]
+## replace [POST /config/replace{?arg}]
 Replaces the config with <file>
 
 Make sure to back up the config file first if neccessary, this operation
@@ -1819,7 +1821,7 @@ can't be undone.
 
 #### curl
 
-    curl -i -F "file=@test" http://localhost:5001/api/v0/config/replace
+    curl -i -X POST -F "file=@test" "http://localhost:5001/api/v0/config/replace"
 
 + Parameters
 
@@ -1829,12 +1831,12 @@ can't be undone.
 
     #### curl
 
-         curl -i "http://localhost:5001/api/v0/config/replace"
+         curl -i -X POST "http://localhost:5001/api/v0/config/replace"
 
     + Body
 
         ```
-        curl -i "http://localhost:5001/api/v0/config/replace"
+        curl -i -X POST "http://localhost:5001/api/v0/config/replace"
         ```
 
 + Response 400
@@ -1864,12 +1866,12 @@ can't be undone.
 
     #### curl
 
-        curl -i -F "file=@test" http://localhost:5001/api/v0/config/replace
+        curl -i -X POST -F "file=@test" http://localhost:5001/api/v0/config/replace
 
     + Body
 
         ```
-        curl -i -F "file=@test" http://localhost:5001/api/v0/config/replace
+        curl -i -X POST -F "file=@test" http://localhost:5001/api/v0/config/replace
         ```
 
 + Response 500
@@ -1903,12 +1905,12 @@ can't be undone.
 
     #### curl
 
-        curl -i -F "file=@test" http://localhost:5001/api/v0/config/replace
+        curl -i -X POST -F "file=@test" http://localhost:5001/api/v0/config/replace
 
     + Body
 
         ```
-        curl -i -F "file=@test" http://localhost:5001/api/v0/config/replace
+        curl -i -X POST -F "file=@test" http://localhost:5001/api/v0/config/replace
         ```
 
 + Response 200
@@ -1947,7 +1949,7 @@ included in the output of this command.
 
     #### curl
 
-        curl -i http://localhost:5001/api/v0/config/show
+        curl -i "http://localhost:5001/api/v0/config/show"
 
     + Body
 
@@ -1987,12 +1989,12 @@ included in the output of this command.
 
     #### curl
 
-        curl -i http://localhost:5001/api/v0/config/show
+        curl -i "http://localhost:5001/api/v0/config/show"
 
     + Body
 
         ```
-        curl -i http://localhost:5001/api/v0/config/show
+        curl -i "http://localhost:5001/api/v0/config/show"
         ```
 
 + Response 200

--- a/apiary.apib
+++ b/apiary.apib
@@ -1515,8 +1515,8 @@ file inside your IPFS repository.
 + Parameters
     + arg1: "Datastore.Path" (string, required) - The key of the config entry.
     + arg2: "~/.ipfs/datastore" (string, optional) - The value to set the config entry to.
-    + bool (boolean, optional) - Set a boolean.
-    + json (boolean, optional) - Parse stringified JSON.
+    + bool (boolean, optional) - Set a boolean. Default: false.
+    + json (boolean, optional) - Parse stringified JSON. Default: false.
 
 + Request Without Arguments
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -1812,7 +1812,7 @@ Opens the config file for editing in $EDITOR
         ```
 
 ## replace [POST /config/replace{?arg}]
-Replaces the config with <file>
+Replaces the config with <file>.
 
 Make sure to back up the config file first if neccessary, this operation
 can't be undone.
@@ -1823,7 +1823,7 @@ can't be undone.
 
 + Parameters
 
-    + arg (string, required) - The file to use as the new config
+    + arg (string, required) - The file to use as the new config.
 
 + Request Without File
 
@@ -1847,8 +1847,7 @@ can't be undone.
         Content-Type: text/plain; charset=utf-8
         ```
 
-    + Attributes
-        - String (string)
+    + Attributes (string)
 
     + Body
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -1622,6 +1622,45 @@ file inside your IPFS repository.
         }
         ```
 
++ Request As SubCommand
+
+    #### curl
+
+        curl -i http://localhost:5001/api/v0/config/API.HTTPHeaders
+
+    + Body
+
+        ```
+        curl -i http://localhost:5001/api/v0/config/API.HTTPHeaders
+        ```
+
++ Response 200
+
+    + Headers
+
+        ```
+        Access-Control-Allow-Headers: X-Stream-Ouptut, X-Chunked-Output
+        Access-Control-Expose-Headers: X-Stream-Ouptut, X-Chunked-Output
+        Content-Type: application/json
+        Trailer: X-Stream-Error
+        Transfer-Encoding: chunked
+        Date: Tue, 02 Feb 2016 16:59:11 GMT
+        Transfer-Encoding: chunked
+        ```
+
+    + Attributes (object)
+        + `Key`: "Datastore" (string)
+        + `Value`: null (object, nullable) - The config entry
+
+    + Body
+
+        ```
+        {
+          "Key": "API.HTTPHeaders",
+          "Value": null
+        }
+        ```
+
 + Request With POST
 
     #### curl

--- a/apiary.apib
+++ b/apiary.apib
@@ -1504,11 +1504,529 @@ Retrieves the object named by <ipfs-or-ipns-path> and outputs the data it contai
 
 # Group config
 
-## edit
+## config [GET /config{?arg1,arg2}{&bool,json}]
 
-## replace
+'ipfs config' controls configuration variables. It works
+much like `git config`. The configuration values are stored in a config
+file inside your IPFS repository.
 
-## show
++ Parameters
+    + arg1: "Datastore.Path" (string, required) - The key of the config entry
+    + arg2: "~/.ipfs/datastore" (string, required) - The value to set the config entry to
+    + bool (boolean, optional) - Set a boolean
+    + json (boolean, optional) - Parse stringified JSON
+
++ Request Without Arguments
+
+    #### curl
+
+        curl -i http://localhost:5001/api/v0/config
+
+    + Body
+
+        ```
+        curl -i http://localhost:5001/api/v0/config
+        ```
+
++ Response 400
+
+    + Headers
+
+        ```
+        Date: Tue, 02 Feb 2016 16:37:00 GMT
+        Content-Length: 26
+        Content-Type: text/plain; charset=utf-8
+        ```
+
+    + Body
+
+        ```
+        Argument 'key' is required
+        ```
+
++ Request With Invalid Argument
+
+    #### curl
+
+        curl -i http://localhost:5001/api/v0/config?arg=kitten
+
+    + Body
+
+        ```
+        curl -i http://localhost:5001/api/v0/config?arg=kitten
+        ```
+
++ Response 500 (application/json)
+
+    + Headers
+
+        ```
+        Access-Control-Allow-Headers: X-Stream-Ouptut, X-Chunked-Output
+        Access-Control-Expose-Headers: X-Stream-Ouptut, X-Chunked-Output
+        Content-Type: application/json
+        Trailer: X-Stream-Error
+        Transfer-Encoding: chunked
+        Date: Tue, 02 Feb 2016 17:04:39 GMT
+        Transfer-Encoding: chunked
+        ```
+
+    + Attributes (Error)
+        + Message: "Failed to get config value:  key has no attributes"
+        + Code: 0
+
+    + Body
+
+        ```
+        {
+          "Message": "Failed to get config value:  key has no attributes",
+          "Code": 0
+        }
+        ```
+
++ Request With Argument
+
+    #### curl
+
+        curl -i http://localhost:5001/api/v0/config?arg=API.HTTPHeaders
+
+    + Body
+
+        ```
+        curl -i http://localhost:5001/api/v0/config?arg=API.HTTPHeaders
+        ```
+
++ Response 200
+
+    + Headers
+
+        ```
+        Access-Control-Allow-Headers: X-Stream-Ouptut, X-Chunked-Output
+        Access-Control-Expose-Headers: X-Stream-Ouptut, X-Chunked-Output
+        Content-Type: application/json
+        Trailer: X-Stream-Error
+        Transfer-Encoding: chunked
+        Date: Tue, 02 Feb 2016 16:59:11 GMT
+        Transfer-Encoding: chunked
+        ```
+
+    + Attributes (object)
+        + `Key`: "Datastore" (string)
+        + `Value`: null (object, nullable) - The config entry
+
+    + Body
+
+        ```
+        {
+          "Key": "API.HTTPHeaders",
+          "Value": null
+        }
+        ```
+
++ Request With POST
+
+    #### curl
+
+        curl -i "http://localhost:5001/api/v0/config?arg=Datastore.Path&arg=kitten"
+
+    + Body
+
+        ```
+        curl -i "http://localhost:5001/api/v0/config?arg=Datastore.Path&arg=kitten"
+        ```
+
++ Response 200
+
+    + Headers
+
+        ```
+        Content-Type: application/json
+        Trailer: X-Stream-Error
+        Transfer-Encoding: chunked
+        Date: Tue, 02 Feb 2016 22:25:00 GMT
+        Transfer-Encoding: chunked
+        ```
+
+    + Attributes (object)
+        - Key: "Datastore.Path" (string)
+        - Value: "kitten" (string)
+
+
+    + Body
+
+        ```
+        {
+          "Key": "Datastore.Path",
+          "Value": "kitten"
+        }
+        ```
+
++ Request With POST and JSON Flag With Invalid JSON Argument
+
+    #### curl
+
+        curl -i "http://localhost:5001/api/v0/config?arg=Datastore.Path&arg=kitten&json"
+
+    + Body
+
+        ```
+        curl -i "http://localhost:5001/api/v0/config?arg=Datastore.Path&arg=kitten&json"
+        ```
+
++ Response 500
+
+    + Headers
+
+        ```
+        Content-Type: application/json
+        Trailer: X-Stream-Error
+        Transfer-Encoding: chunked
+        Date: Tue, 02 Feb 2016 22:26:11 GMT
+        Transfer-Encoding: chunked
+        ```
+
+    + Attributes (Error)
+        - Message: "failed to unmarshal json. invalid character 'k' looking for beginning of value"
+        - Code: 0
+
+
+    + Body
+
+        ```
+        {
+          "Message": "failed to unmarshal json. invalid character 'k' looking for beginning of value",
+          "Code": 0
+        }
+        ```
+
++ Request With POST and JSON Flag With Valid JSON Argument
+
+    #### curl
+
+        curl -i "http://localhost:5001/api/v0/config?arg=Datastore.Path&arg=\"kitten\"&json"
+
+    + Body
+
+        ```
+        curl -i "http://localhost:5001/api/v0/config?arg=Datastore.Path&arg=\"kitten\"&json"
+        ```
+
++ Response 200
+
+    + Headers
+
+        ```
+        Content-Type: application/json
+        Trailer: X-Stream-Error
+        Transfer-Encoding: chunked
+        Date: Tue, 02 Feb 2016 22:28:37 GMT
+        Transfer-Encoding: chunked
+        ```
+
+    + Attributes (object)
+        - Key: "Datastore.Path" (string)
+        - Value: "kitten" (string)
+
+
+    + Body
+
+        ```
+        {
+          "Key": "Datastore.Path",
+          "Value": "kitten"
+        }
+        ```
+
+## edit [GET /config/edit]
+Opens the config file for editing in $EDITOR
+
++ Request
+
+    ### curl
+
+        curl -i http://localhost:5001/api/v0/config/edit
+
+    + Body
+
+        ```
+        curl -i http://localhost:5001/api/v0/config/edit
+        ```
+
++ Response 200
+
+    + Headers
+
+        ```
+        Access-Control-Allow-Headers: X-Stream-Ouptut, X-Chunked-Output
+        Access-Control-Expose-Headers: X-Stream-Ouptut, X-Chunked-Output
+        Content-Type: application/json
+        Trailer: X-Stream-Error
+        Transfer-Encoding: chunked
+        Date: Tue, 02 Feb 2016 17:54:56 GMT
+        Transfer-Encoding: chunked
+        ```
+
+    + Attributes
+
+    + Body
+
+        ```
+        ```
+
+## replace [GET /config/replace{?arg}]
+Replaces the config with <file>
+
+Make sure to back up the config file first if neccessary, this operation
+can't be undone.
+
+#### curl
+
+    curl -i -F "file=@test" http://localhost:5001/api/v0/config/replace
+
++ Parameters
+
+    + arg (string, required) - The file to use as the new config
+
++ Request Without File
+
+    #### curl
+
+         curl -i "http://localhost:5001/api/v0/config/replace"
+
+    + Body
+
+        ```
+        curl -i "http://localhost:5001/api/v0/config/replace"
+        ```
+
++ Response 400
+
+    + Headers
+
+        ```
+        Date: Tue, 02 Feb 2016 22:31:15 GMT
+        Content-Length: 32
+        Content-Type: text/plain; charset=utf-8
+        ```
+
+    + Attributes
+        - String (string)
+
+    + Body
+
+        ```
+        File argument 'file' is required
+        ```
+
+
++ Request With Badly Configured Config File
+
+    Where 'test' is a file that is not JSON and does not conform to the
+    standard IPFS config file structure.
+
+    #### curl
+
+        curl -i -F "file=@test" http://localhost:5001/api/v0/config/replace
+
+    + Body
+
+        ```
+        curl -i -F "file=@test" http://localhost:5001/api/v0/config/replace
+        ```
+
++ Response 500
+
+    + Headers
+
+        ```
+        Access-Control-Allow-Headers: X-Stream-Ouptut, X-Chunked-Output
+        Access-Control-Expose-Headers: X-Stream-Ouptut, X-Chunked-Output
+        Content-Type: application/json
+        Trailer: X-Stream-Error
+        Transfer-Encoding: chunked
+        Date: Tue, 02 Feb 2016 21:27:01 GMT
+        Transfer-Encoding: chunked
+        ```
+
+    + Attributes (Error)
+        - Message: "Failed to decode file as config" (string)
+        - Code: 0 (number)
+
+    + Body
+
+        ```
+        {
+          "Message": "Failed to decode file as config",
+          "Code": 0
+        }
+        ```
+
++ Request With Config File
+
+    #### curl
+
+        curl -i -F "file=@test" http://localhost:5001/api/v0/config/replace
+
+    + Body
+
+        ```
+        curl -i -F "file=@test" http://localhost:5001/api/v0/config/replace
+        ```
+
++ Response 200
+
+    + Headers
+
+        ```
+        Access-Control-Allow-Headers: X-Stream-Ouptut, X-Chunked-Output
+        Access-Control-Expose-Headers: X-Stream-Ouptut, X-Chunked-Output
+        Content-Type: application/json
+        Trailer: X-Stream-Error
+        Transfer-Encoding: chunked
+        Date: Tue, 02 Feb 2016 21:29:55 GMT
+        Transfer-Encoding: chunked
+        ```
+
+    + Attributes
+
+    + Body
+
+        ```
+        ```
+
+## show [GET /config/show]
+Outputs the content of the config file
+
+**Warning**
+
+Your private key is stored in the config file, and it will be
+included in the output of this command.
+
++ Request Without Config File
+
+    This request is shown as an example, presuming that ~/.ipfs/config has been
+    deleted, not that it hasn't been specified in the request.
+
+    #### curl
+
+        curl -i http://localhost:5001/api/v0/config/show
+
+    + Body
+
+        ```
+        curl -i http://localhost:5001/api/v0/config/show
+        ```
+
++ Response 500
+
+    + Headers
+
+        ```
+        Access-Control-Allow-Headers: X-Stream-Ouptut, X-Chunked-Output
+        Access-Control-Expose-Headers: X-Stream-Ouptut, X-Chunked-Output
+        Content-Type: application/json
+        Trailer: X-Stream-Error
+        Transfer-Encoding: chunked
+        Date: Tue, 02 Feb 2016 21:38:55 GMT
+        Transfer-Encoding: chunked
+        ```
+
+    + Attributes (Error)
+        - Message: "open /Users/richard/.ipfs/config: no such file or directory" (string)
+        - Code: 0 (number)
+
+    + Body
+
+        ```
+        {
+          "Message": "open /Users/richard/.ipfs/config: no such file or directory",
+          "Code": 0
+        }
+        ```
+
+
++ Request (multipart/form-data)
+
+    #### curl
+
+        curl -i http://localhost:5001/api/v0/config/show
+
+    + Body
+
+        ```
+        curl -i http://localhost:5001/api/v0/config/show
+        ```
+
++ Response 200
+
+    A body is not included here in order to obfuscate the private key.
+
+    + Headers
+
+        ```
+        Access-Control-Allow-Headers: X-Stream-Ouptut, X-Chunked-Output
+        Access-Control-Expose-Headers: X-Stream-Ouptut, X-Chunked-Output
+        Content-Type: text/plain
+        Trailer: X-Stream-Error
+        Transfer-Encoding: chunked
+        X-Stream-Output: 1
+        Date: Tue, 02 Feb 2016 21:33:14 GMT
+        Transfer-Encoding: chunked
+        ```
+
+    + Attributes (object)
+        + `API` (object)
+            + `HTTPHeaders`: null (string, nullable)
+        + `Addresses` (object)
+            + `API`: "/ip4/127.0.0.1/tcp/5001" (MultiAddr)
+            + `Gateway`: "/ip4/127.0.0.1/tcp/8080" (MultiAddr)
+            + `Swarm` (array)
+                - (SwarmAddrs)
+        + `Bootstrap` (array)
+            - MultiAddr (MultiAddr)
+        + `Datastore` (object)
+            - `GCPeriod`: "" (string)
+            - `NoSync`: false (boolean)
+            - `Params`: null (string, nullable)
+            - `Path`: "" (string)
+            - `StorageGCWatermark`: 90 (number)
+            - `StorageMax`: "10GB" (string)
+            - `Type`: "" (string)
+        + `Discovery` (object)
+            + `MDNS` (object)
+                - `Enabled`: true (boolean)
+                - `Interval`: 10 (number)
+        + `Gateway` (object)
+            - `HTTPHeaders`: null (string, nullable)
+            - `RootRedirect`: "" (string)
+            - `Writable`: false (boolean)
+        + `Identity` (object)
+            - `PeerID`: hash (Multihash)
+            - `PrivKey`: hash (string)
+        + `Ipns` (object)
+            - `RecordLifetime`: "" (string)
+            - `RepublishPeriod`: "" (string)
+            - `ResolveCacheSize`: 128 (number)
+        + `Log` (object)
+            - `MaxAgeDays`: 0 (number)
+            - `MaxBackups`: 1 (number)
+            - `MaxSizeMB`: 250 (number)
+        + `Mounts` (object)
+            - `FuseAllowOther`: false (boolean)
+            - `IPFS`: "/ipfs" (string)
+            - `IPFS`: "/ipns" (string)
+        + `SupernodeRouting` (object)
+            + `Servers` (array)
+                - (SwarmAddrs)
+        + `Swarm` (object)
+            - `AddrFilters`: null (string, nullable)
+        + `Tour` (object)
+            - `Last`: "" (string)
+        + `Version` (object)
+            - `AutoUpdate`: "minor" (string)
+            - `Check`: "error" (string)
+            - `CheckDate`: "0001-01-01T00:00:00Z" (string)
+            - `CheckPeriod`: "172800000000000" (string)
+            - `Current`: "0.3.11-dev" (string)
 
 # Group daemon
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -1948,7 +1948,7 @@ included in the output of this command.
         ```
 
 
-+ Request (multipart/form-data)
++ Request
 
     #### curl
 
@@ -1962,7 +1962,7 @@ included in the output of this command.
 
 + Response 200
 
-    A body is not included here in order to obfuscate the private key.
+    A Body is not included here in order to obfuscate the private key.
 
     + Headers
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -2064,7 +2064,8 @@ included in the output of this command.
             - `Check`: "error" (string)
             - `CheckDate`: "0001-01-01T00:00:00Z" (string)
             - `CheckPeriod`: "172800000000000" (string)
-            - `Current`: "0.3.11-dev" (string)
+            - `Current`: "0.4.0-dev" (string)
+        + `id` (Multihash)
 
 # Group daemon
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -1777,40 +1777,6 @@ file inside your IPFS repository.
         }
         ```
 
-## edit [GET /config/edit]
-Opens the config file for editing in $EDITOR
-
-+ Request
-
-    ### curl
-
-        curl -i "http://localhost:5001/api/v0/config/edit"
-
-    + Body
-
-        ```
-        curl -i "http://localhost:5001/api/v0/config/edit"
-        ```
-
-+ Response 200
-
-    + Headers
-
-        ```
-        Access-Control-Allow-Headers: X-Stream-Ouptut, X-Chunked-Output
-        Access-Control-Expose-Headers: X-Stream-Ouptut, X-Chunked-Output
-        Content-Type: application/json
-        Trailer: X-Stream-Error
-        Transfer-Encoding: chunked
-        Date: Tue, 02 Feb 2016 17:54:56 GMT
-        Transfer-Encoding: chunked
-        ```
-
-    + Body
-
-        ```
-        ```
-
 ## replace [POST /config/replace{?arg}]
 Replaces the config with <file>.
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -1514,7 +1514,7 @@ file inside your IPFS repository.
 
 + Parameters
     + arg1: "Datastore.Path" (string, required) - The key of the config entry.
-    + arg2: "~/.ipfs/datastore" (string, required) - The value to set the config entry to.
+    + arg2: "~/.ipfs/datastore" (string, optional) - The value to set the config entry to.
     + bool (boolean, optional) - Set a boolean.
     + json (boolean, optional) - Parse stringified JSON.
 


### PR DESCRIPTION
Some issues:
- ~~I was unable to get the second argument working, so it is currently not documented how to patch a config entry. I also was unable to meaningfully get `bool` and `json` flags working.~~ Wireshark says that `encoding=json` is added to each command normally run by the CLI, as well as `stream-channels=true`, but neither of these are mentioned in the CLI mans, which is odd. I'm not sure what they are doing. 
- 'ipfs config edit' opens up a second terminal window - over the running daemon -  when requested using curl on the commandline, so I'm not actually sure what that should be doing in the API. I had it originally set as content-type buffer in the request, too, but I'm not sure where I got that; probably Postman. It wasn't shown in Wireshark. 
- Some of the commands returned no body in the CLI when curled, but returned malformed JSON in Wireshark. Not sure what to make of that. 
