### PR TITLE
Added Group `dht`

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -2946,7 +2946,7 @@ it returns no extra information in the ndjson response.
         ```
 
 ## query [GET /dht/query{?arg}{&verbose}]
-Run a `findClosestPeers` query through the DHT
+Find the closest peers to a given key by querying through the DHT.
 
 #### Bugs
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -1425,6 +1425,7 @@ in the bootstrap list).
 
     #### curl
 
+
          curl -i http://localhost:5001/api/v0/bootstrap/add?default
 
     + Body
@@ -2469,15 +2470,572 @@ included in the output of this command.
 
 # Group dht
 
-## findpeer
+Issue commands directly through the DHT.
 
-## findprovs
+This command can't be called directly.
 
-## get
+## findpeer [GET /dht/findpeer{?arg}]
+Run a `FindPeer` query through the DHT.
 
-## put
++ Parameters
+    + arg (string, required) - <peerid> The peer to search for.
 
-## query
++ Request Without Arguments
+
+    #### curl
+
+        curl -i "http://localhost:5001/api/v0/dht/findpeer"
+
+    + Body
+
+        ```
+        curl -i "http://localhost:5001/api/v0/dht/findpeer"
+        ```
+
++ Response 400
+
+    + Headers
+
+        ```
+        Content-Type: application/json
+        Trailer: X-Stream-Error
+        Transfer-Encoding: chunked
+        Date: Sat, 06 Feb 2016 22:44:12 GMT
+        Transfer-Encoding: chunked
+        ```
+
+    + Attributes (string)
+
+    + Body
+
+        ```
+        Argument 'peerID' is required
+        ```
+
++ Request With Empty Argument
+
+    #### curl
+
+        curl -i "http://localhost:5001/api/v0/dht/findpeer?arg="
+
+    + Body
+
+        ```
+        curl -i "http://localhost:5001/api/v0/dht/findpeer?arg="
+        ```
+
++ Response 500
+
+    + Headers
+
+        ```
+        Content-Type: application/json
+        Trailer: X-Stream-Error
+        Transfer-Encoding: chunked
+        Date: Sat, 06 Feb 2016 22:45:18 GMT
+        Transfer-Encoding: chunked
+        ```
+
+    + Attributes (Error)
+        - Message: "multihash too short. must be \u003e 3 bytes"
+        - Code: 0
+
+    + Body
+
+        ```
+        {
+          "Message": "multihash too short. must be \u003e 3 bytes",
+          "Code": 0
+        }
+        ```
+
++ Request With Invalid Argument
+
+    #### curl
+
+        curl -i "http://localhost:5001/api/v0/dht/findpeer?arg=kitten"
+
+    + Body
+
+        ```
+        curl -i "http://localhost:5001/api/v0/dht/findpeer?arg=kitten"
+        ```
+
++ Response 500
+
+
+    + Headers
+
+        ```
+        Content-Type: application/json
+        Trailer: X-Stream-Error
+        Transfer-Encoding: chunked
+        Date: Sat, 06 Feb 2016 22:45:12 GMT
+        Transfer-Encoding: chunked
+        ```
+
+    + Attributes (Error)
+        - Message: "multihash length inconsistent: \u0026{6  174 [128 54 35]}"
+        - Code: 0
+
+    + Body
+
+        ```
+        {
+          "Message": "multihash length inconsistent: \u0026{6  174 [128 54 35]}",
+          "Code": 0
+        }
+        ```
+
++ Request With Argument
+
+    #### curl
+
+        curl -i "http://localhost:5001/api/v0/dht/findpeer?arg=QmW2WQi7j6c7UgJTarActp7tDNikE4B2qXtFCfLPdsgaTQ"
+
+    + Body
+
+        ```
+        curl -i "http://localhost:5001/api/v0/dht/findpeer?arg=QmW2WQi7j6c7UgJTarActp7tDNikE4B2qXtFCfLPdsgaTQ"
+        ```
+
++ Response 200
+
+    The response has been truncated to a single ndjson object, as the responses are streamed.
+
+    + Headers
+
+        ```
+        Content-Type: application/json
+        Trailer: X-Stream-Error
+        Transfer-Encoding: chunked
+        X-Chunked-Output: 1
+        Date: Sat, 06 Feb 2016 22:46:50 GMT
+        Transfer-Encoding: chunked
+        ```
+
+    + Attributes (ndjson)
+        - Extra (string)
+        - ID (Multihash)
+        + Responses (array)
+            + (object)
+                - Addrs (MultiAddr)
+                - ID (Multihash)
+        - Type (number)
+
+    + Body
+
+        ```
+        {
+          "Extra": "",
+          "ID": "QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd",
+          "Responses": null,
+          "Type": 0
+        }
+        ```
+
+## findprovs [POST /dht/findprovs{?arg}{&verbose}]
+Run a `FindProviders` query through the DHT.
+
+FindProviders will return a list of peers who are able to provide the value requested.
+
+#### Bugs
+
+- While `verbose` is specified in the HTTP API and is used in the HTTP request,
+it returns no extra information in the ndjson response.
+- An invalid or empty key returns the same response as a normal one.
+
++ Parameters
+    + arg (string, required) - The key to find providers for
+    + verbose (boolean, optional) - Write extra information
+
++ Request Without Arguments
+
+    #### curl
+
+        curl -i -X POST "http://localhost:5001/api/v0/dht/findprovs"
+
+    + Body
+
+        ```
+        curl -i -X POST "http://localhost:5001/api/v0/dht/findprovs"
+        ```
+
++ Response 400
+
+    + Headers
+
+        ```
+        Date: Sat, 06 Feb 2016 22:50:36 GMT
+        Content-Length: 26
+        Content-Type: text/plain; charset=utf-8
+        ```
+
+    + Attributes (string)
+
+    + Body
+
+        ```
+        Argument 'key' is required
+        ```
+
++ Request With Argument
+
+    The response is the same if the argument is empty or invalid. For example:
+
+        curl -i -X POST "http://localhost:5001/api/v0/dht/findprovs?arg=kitten"
+
+    #### curl
+
+        curl -i -X POST "http://localhost:5001/api/v0/dht/findprovs?arg="
+
+    + Body
+
+        ```
+        curl -i -X POST "http://localhost:5001/api/v0/dht/findprovs?arg="
+        ```
+
++ Response 200
+
+    + Headers
+
+        ```
+        Content-Type: application/json
+        Trailer: X-Stream-Error
+        Transfer-Encoding: chunked
+        X-Chunked-Output: 1
+        Date: Sat, 06 Feb 2016 22:51:01 GMT
+        Transfer-Encoding: chunked
+        ```
+
+    + Attributes (ndjson)
+        - Extra (string)
+        - ID (Multihash)
+        + Responses (array)
+            + (object)
+                - Addrs (MultiAddr)
+                - ID (Multihash)
+        - Type (number)
+
+    + Body
+
+        ```
+        {
+          "Extra": "",
+          "ID": "QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd",
+          "Responses": null,
+          "Type": 0
+        }
+        ```
+
+## get [GET /dht/get{?arg}{&verbose}]
+Run a `GetValue` query through the DHT
+
+GetValue will return the value stored in the DHT at the given key.
+
+#### Bugs
+
+- While `verbose` is specified in the HTTP API and is used in the HTTP request,
+it returns no extra information in the ndjson response.
+- An invalid or empty key returns the same response as a normal one.
+
++ Parameters
+    + arg (string, required) - The key to find providers for
+    + verbose (boolean, optional) - Write extra information
+
++ Request Without Arguments
+
+    #### curl
+
+        curl -i "http://localhost:5001/api/v0/dht/get"
+
+    + Body
+
+        ```
+        curl -i "http://localhost:5001/api/v0/dht/get"
+        ```
+
++ Response 400
+
+    + Headers
+
+        ```
+        Date: Sat, 06 Feb 2016 22:59:08 GMT
+        Content-Length: 26
+        Content-Type: text/plain; charset=utf-8
+        ```
+
+    + Attributes (string)
+
+    + Body
+
+        ```
+        Argument 'key' is required
+        ```
+
++ Request With Argument
+
+    The response is the same if the argument is empty or invalid. For example:
+
+    #### curl
+
+        curl -i "http://localhost:5001/api/v0/dht/get?arg=QmW2WQi7j6c7UgJTarActp7tDNikE4B2qXtFCfLPdsgaTQ"
+
+    + Body
+
+        ```
+        curl -i "http://localhost:5001/api/v0/dht/get?arg=QmW2WQi7j6c7UgJTarActp7tDNikE4B2qXtFCfLPdsgaTQ"
+        ```
+
++ Response 200
+
+    + Headers
+
+        ```
+        Content-Type: application/json
+        Trailer: X-Stream-Error
+        Transfer-Encoding: chunked
+        X-Chunked-Output: 1
+        Date: Sat, 06 Feb 2016 22:59:25 GMT
+        Transfer-Encoding: chunked
+        ```
+
+    + Attributes (ndjson)
+        - Extra (string)
+        - ID (Multihash)
+        + Responses (array)
+            + (object)
+                - Addrs (MultiAddr)
+                - ID (Multihash)
+        - Type (number)
+
+    + Body
+
+        ```
+        {
+          "Extra": "",
+          "ID": "QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd",
+          "Responses": null,
+          "Type": 0
+        }
+        ```
+
+## put [GET /dht/put{?arg1,arg2}{&verbose}]
+Run a `PutValue` query through the DHT
+
+PutValue will store the given key value pair in the DHT.
+
+#### Bugs
+
+- While `verbose` is specified in the HTTP API and is used in the HTTP request,
+it returns no extra information in the ndjson response.
+- An invalid or empty key returns the same response as a normal one.
+
++ Parameters
+    + arg1 (string, required) - The key to store the value at.
+    + arg2 (string, required) - The value to store.
+    + verbose (boolean, optional) - Write extra information.
+
++ Request Without Arguments
+
+    #### curl
+
+        curl -i "http://localhost:5001/api/v0/dht/put"
+
+    + Body
+
+        ```
+        curl -i "http://localhost:5001/api/v0/dht/put"
+        ```
+
++ Response 400
+
+    + Headers
+
+        ```
+        Date: Sat, 06 Feb 2016 23:01:30 GMT
+        Content-Length: 26
+        Content-Type: text/plain; charset=utf-8
+        ```
+
+    + Attributes (string)
+
+    + Body
+
+        ```
+        Argument 'key' is required
+        ```
+
++ Request With Empty Or Invalid First Argument
+
+    #### curl
+
+        curl -i "http://localhost:5001/api/v0/dht/put?arg="
+
+    + Body
+
+        ```
+        curl -i "http://localhost:5001/api/v0/dht/put?arg="
+        ```
+
++ Response 400
+
+    + Headers
+
+        ```
+        Date: Sat, 06 Feb 2016 23:02:04 GMT
+        Content-Length: 28
+        Content-Type: text/plain; charset=utf-8
+        ```
+
+    + Attributes (string
+
+    + Body
+
+        ```
+        Argument 'value' is required
+        ```
+
++ Request With Arguments
+
+    The response is the same if either argument is empty or invalid. For example:
+
+        curl -i "http://localhost:5001/api/v0/dht/put?arg=&arg="
+
+    #### curl
+
+        curl -i "http://localhost:5001/api/v0/dht/put?arg=kitten"
+
+    + Body
+
+        ```
+        curl -i "http://localhost:5001/api/v0/dht/put?arg=kitten"
+        ```
+
++ Response 200
+
+    + Headers
+
+        ```
+        Content-Type: application/json
+        Trailer: X-Stream-Error
+        Transfer-Encoding: chunked
+        X-Chunked-Output: 1
+        Date: Sat, 06 Feb 2016 22:59:25 GMT
+        Transfer-Encoding: chunked
+        ```
+
+    + Attributes (ndjson)
+        - Extra (string)
+        - ID (Multihash)
+        + Responses (array)
+            + (object)
+                - Addrs (MultiAddr)
+                - ID (Multihash)
+        - Type (number)
+
+    + Body
+
+        ```
+        {
+          "Extra": "",
+          "ID": "QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd",
+          "Responses": null,
+          "Type": 0
+        }
+        ```
+
+## query [GET /dht/query{?arg}{&verbose}]
+Run a `findClosestPeers` query through the DHT
+
+#### Bugs
+
+- While `verbose` is specified in the HTTP API and is used in the HTTP request,
+it returns no extra information in the ndjson response.
+- An invalid or empty key returns the same response as a normal one.
+
++ Parameters
+    + arg (string, required) - <peerid> The peerID to run the query against
+    + verbose (boolean, optional) -  Write extra information
+
++ Request Without Arguments
+
+    The response is the same if either argument is empty or invalid. For example:
+
+        curl -i "http://localhost:5001/api/v0/dht/put?arg=&arg="
+
+    #### curl
+
+        curl -i "http://localhost:5001/api/v0/dht/query"
+
+    + Body
+
+        ```
+        curl -i "http://localhost:5001/api/v0/dht/query"
+        ```
+
++ Response 400
+
+    + Headers
+
+        ```
+        Date: Sat, 06 Feb 2016 23:04:52 GMT
+        Content-Length: 29
+        Content-Type: text/plain; charset=utf-8
+        ```
+
+    + Attributes (string)
+
+    + Body
+
+        ```
+        Argument 'peerID' is required
+        ```
+
++ Request With Argument
+
+    #### curl
+
+        curl -i "http://localhost:5001/api/v0/dht/query?arg=QmW2WQi7j6c7UgJTarActp7tDNikE4B2qXtFCfLPdsgaTQ"
+
+    + Body
+
+        ```
+        curl -i "http://localhost:5001/api/v0/dht/query?arg=QmW2WQi7j6c7UgJTarActp7tDNikE4B2qXtFCfLPdsgaTQ"
+        ```
+
++ Response 200
+
+    + Headers
+
+        ```
+        Content-Type: application/json
+        Trailer: X-Stream-Error
+        Transfer-Encoding: chunked
+        X-Chunked-Output: 1
+        Date: Sat, 06 Feb 2016 22:59:25 GMT
+        Transfer-Encoding: chunked
+        ```
+
+    + Attributes (ndjson)
+        - Extra (string)
+        - ID (Multihash)
+        + Responses (array)
+            + (object)
+                - Addrs (MultiAddr)
+                - ID (Multihash)
+        - Type (number)
+
+    + Body
+
+        ```
+        {
+          "Extra": "",
+          "ID": "QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd",
+          "Responses": null,
+          "Type": 0
+        }
+        ```
 
 # Group diag
 Generate diagnostic reports.

--- a/apiary.apib
+++ b/apiary.apib
@@ -2478,7 +2478,7 @@ This command can't be called directly.
 Run a `FindPeer` query through the DHT.
 
 + Parameters
-    + arg (string, required) - <peerid> The peer to search for.
+    + arg (string, required) - The peer to search for.
 
 + Request Without Arguments
 
@@ -2634,20 +2634,13 @@ Run a `FindPeer` query through the DHT.
         }
         ```
 
-## findprovs [POST /dht/findprovs{?arg}{&verbose}]
+## findprovs [POST /dht/findprovs{?arg}]
 Run a `FindProviders` query through the DHT.
 
 FindProviders will return a list of peers who are able to provide the value requested.
 
-#### Bugs
-
-- While `verbose` is specified in the HTTP API and is used in the HTTP request,
-it returns no extra information in the ndjson response.
-- An invalid or empty key returns the same response as a normal one.
-
 + Parameters
-    + arg (string, required) - The key to find providers for
-    + verbose (boolean, optional) - Write extra information
+    + arg (string, required) - The key to find providers for.
 
 + Request Without Arguments
 
@@ -2687,15 +2680,17 @@ it returns no extra information in the ndjson response.
 
     #### curl
 
-        curl -i -X POST "http://localhost:5001/api/v0/dht/findprovs?arg="
+        curl -i -X POST "http://localhost:5001/api/v0/dht/findprovs?arg=QmW2WQi7j6c7UgJTarActp7tDNikE4B2qXtFCfLPdsgaTQ"
 
     + Body
 
         ```
-        curl -i -X POST "http://localhost:5001/api/v0/dht/findprovs?arg="
+        curl -i -X POST "http://localhost:5001/api/v0/dht/findprovs?arg=QmW2WQi7j6c7UgJTarActp7tDNikE4B2qXtFCfLPdsgaTQ"
         ```
 
 + Response 200
+
+    The response has been truncated to a single ndjson object, as the responses are streamed.
 
     + Headers
 
@@ -2728,20 +2723,13 @@ it returns no extra information in the ndjson response.
         }
         ```
 
-## get [GET /dht/get{?arg}{&verbose}]
-Run a `GetValue` query through the DHT
+## get [GET /dht/get{?arg}]
+Run a `GetValue` query through the DHT.
 
 GetValue will return the value stored in the DHT at the given key.
 
-#### Bugs
-
-- While `verbose` is specified in the HTTP API and is used in the HTTP request,
-it returns no extra information in the ndjson response.
-- An invalid or empty key returns the same response as a normal one.
-
 + Parameters
     + arg (string, required) - The key to find providers for
-    + verbose (boolean, optional) - Write extra information
 
 + Request Without Arguments
 
@@ -2777,6 +2765,8 @@ it returns no extra information in the ndjson response.
 
     The response is the same if the argument is empty or invalid. For example:
 
+        curl -i "http://localhost:5001/api/v0/dht/get?arg=\[kitten\]"
+
     #### curl
 
         curl -i "http://localhost:5001/api/v0/dht/get?arg=QmW2WQi7j6c7UgJTarActp7tDNikE4B2qXtFCfLPdsgaTQ"
@@ -2788,6 +2778,8 @@ it returns no extra information in the ndjson response.
         ```
 
 + Response 200
+
+    The response has been truncated to a single ndjson object, as the responses are streamed.
 
     + Headers
 
@@ -2820,21 +2812,14 @@ it returns no extra information in the ndjson response.
         }
         ```
 
-## put [GET /dht/put{?arg1,arg2}{&verbose}]
-Run a `PutValue` query through the DHT
+## put [GET /dht/put{?arg1,arg2}]
+Run a `PutValue` query through the DHT.
 
 PutValue will store the given key value pair in the DHT.
-
-#### Bugs
-
-- While `verbose` is specified in the HTTP API and is used in the HTTP request,
-it returns no extra information in the ndjson response.
-- An invalid or empty key returns the same response as a normal one.
 
 + Parameters
     + arg1 (string, required) - The key to store the value at.
     + arg2 (string, required) - The value to store.
-    + verbose (boolean, optional) - Write extra information.
 
 + Request Without Arguments
 
@@ -2888,7 +2873,7 @@ it returns no extra information in the ndjson response.
         Content-Type: text/plain; charset=utf-8
         ```
 
-    + Attributes (string
+    + Attributes (string)
 
     + Body
 
@@ -2904,12 +2889,12 @@ it returns no extra information in the ndjson response.
 
     #### curl
 
-        curl -i "http://localhost:5001/api/v0/dht/put?arg=kitten"
+        curl -i "http://localhost:5001/api/v0/dht/put?arg=kitten&arg=true"
 
     + Body
 
         ```
-        curl -i "http://localhost:5001/api/v0/dht/put?arg=kitten"
+        curl -i "http://localhost:5001/api/v0/dht/put?arg=kitten&arg=true"
         ```
 
 + Response 200
@@ -2945,24 +2930,13 @@ it returns no extra information in the ndjson response.
         }
         ```
 
-## query [GET /dht/query{?arg}{&verbose}]
+## query [GET /dht/query{?arg}]
 Find the closest peers to a given key by querying through the DHT.
 
-#### Bugs
-
-- While `verbose` is specified in the HTTP API and is used in the HTTP request,
-it returns no extra information in the ndjson response.
-- An invalid or empty key returns the same response as a normal one.
-
 + Parameters
-    + arg (string, required) - <peerid> The peerID to run the query against
-    + verbose (boolean, optional) -  Write extra information
+    + arg (string, required) - The peerID to run the query against.
 
 + Request Without Arguments
-
-    The response is the same if either argument is empty or invalid. For example:
-
-        curl -i "http://localhost:5001/api/v0/dht/put?arg=&arg="
 
     #### curl
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -2633,7 +2633,18 @@ Run a `FindPeer` query through the DHT.
         {
           "Extra": "",
           "ID": "QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd",
-          "Responses": null,
+          "Responses": [
+              {
+                "Addrs": [
+                  "/ip4/10.0.0.116/tcp/14001",
+                  "/ip4/127.0.0.1/tcp/14001",
+                  "/ip4/127.0.0.2/tcp/14001",
+                  "/ip4/62.210.92.54/tcp/14001"
+                ],
+                "ID": "QmdmznJmndCNmfDNZ6pLSFuihXwgSnHbienWCJzJQ4M8By"
+              },
+              ...
+          ],
           "Type": 0
         }
         ```
@@ -2724,7 +2735,18 @@ FindProviders will return a list of peers who are able to provide the value requ
         {
           "Extra": "",
           "ID": "QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd",
-          "Responses": null,
+          "Responses": [
+              {
+                "Addrs": [
+                  "/ip4/10.0.0.116/tcp/14001",
+                  "/ip4/127.0.0.1/tcp/14001",
+                  "/ip4/127.0.0.2/tcp/14001",
+                  "/ip4/62.210.92.54/tcp/14001"
+                ],
+                "ID": "QmdmznJmndCNmfDNZ6pLSFuihXwgSnHbienWCJzJQ4M8By"
+              },
+              ...
+          ],
           "Type": 0
         }
         ```
@@ -2813,7 +2835,18 @@ GetValue will return the value stored in the DHT at the given key.
         {
           "Extra": "",
           "ID": "QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd",
-          "Responses": null,
+          "Responses": [
+              {
+                "Addrs": [
+                  "/ip4/10.0.0.116/tcp/14001",
+                  "/ip4/127.0.0.1/tcp/14001",
+                  "/ip4/127.0.0.2/tcp/14001",
+                  "/ip4/62.210.92.54/tcp/14001"
+                ],
+                "ID": "QmdmznJmndCNmfDNZ6pLSFuihXwgSnHbienWCJzJQ4M8By"
+              },
+              ...
+          ],
           "Type": 0
         }
         ```
@@ -2931,10 +2964,23 @@ PutValue will store the given key value pair in the DHT.
         {
           "Extra": "",
           "ID": "QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd",
-          "Responses": null,
+          "Responses": [
+              {
+                "Addrs": [
+                  "/ip4/10.0.0.116/tcp/14001",
+                  "/ip4/127.0.0.1/tcp/14001",
+                  "/ip4/127.0.0.2/tcp/14001",
+                  "/ip4/62.210.92.54/tcp/14001"
+                ],
+                "ID": "QmdmznJmndCNmfDNZ6pLSFuihXwgSnHbienWCJzJQ4M8By"
+              },
+              ...
+          ],
           "Type": 0
         }
         ```
+
+
 
 ## query [GET /dht/query{?arg}]
 Find the closest peers to a given key by querying through the DHT.
@@ -3014,7 +3060,18 @@ Find the closest peers to a given key by querying through the DHT.
         {
           "Extra": "",
           "ID": "QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd",
-          "Responses": null,
+          "Responses": [
+              {
+                "Addrs": [
+                  "/ip4/10.0.0.116/tcp/14001",
+                  "/ip4/127.0.0.1/tcp/14001",
+                  "/ip4/127.0.0.2/tcp/14001",
+                  "/ip4/62.210.92.54/tcp/14001"
+                ],
+                "ID": "QmdmznJmndCNmfDNZ6pLSFuihXwgSnHbienWCJzJQ4M8By"
+              },
+              ...
+          ],
           "Type": 0
         }
         ```

--- a/apiary.apib
+++ b/apiary.apib
@@ -2497,11 +2497,9 @@ Run a `FindPeer` query through the DHT.
     + Headers
 
         ```
-        Content-Type: application/json
-        Trailer: X-Stream-Error
-        Transfer-Encoding: chunked
-        Date: Sat, 06 Feb 2016 22:44:12 GMT
-        Transfer-Encoding: chunked
+        Date: Wed, 13 Apr 2016 14:08:32 GMT
+        Content-Length: 29
+        Content-Type: text/plain; charset=utf-8
         ```
 
     + Attributes (string)
@@ -2529,10 +2527,12 @@ Run a `FindPeer` query through the DHT.
     + Headers
 
         ```
+        Access-Control-Allow-Headers: X-Stream-Output, X-Chunked-Output, X-Content-Length
+        Access-Control-Expose-Headers: X-Stream-Output, X-Chunked-Output, X-Content-Length
         Content-Type: application/json
+        Server: go-ipfs/0.4.1-dev
         Trailer: X-Stream-Error
-        Transfer-Encoding: chunked
-        Date: Sat, 06 Feb 2016 22:45:18 GMT
+        Date: Wed, 13 Apr 2016 14:08:49 GMT
         Transfer-Encoding: chunked
         ```
 
@@ -2567,10 +2567,12 @@ Run a `FindPeer` query through the DHT.
     + Headers
 
         ```
+        Access-Control-Allow-Headers: X-Stream-Output, X-Chunked-Output, X-Content-Length
+        Access-Control-Expose-Headers: X-Stream-Output, X-Chunked-Output, X-Content-Length
         Content-Type: application/json
+        Server: go-ipfs/0.4.1-dev
         Trailer: X-Stream-Error
-        Transfer-Encoding: chunked
-        Date: Sat, 06 Feb 2016 22:45:12 GMT
+        Date: Wed, 13 Apr 2016 14:09:05 GMT
         Transfer-Encoding: chunked
         ```
 
@@ -2606,11 +2608,13 @@ Run a `FindPeer` query through the DHT.
     + Headers
 
         ```
+        Access-Control-Allow-Headers: X-Stream-Output, X-Chunked-Output, X-Content-Length
+        Access-Control-Expose-Headers: X-Stream-Output, X-Chunked-Output, X-Content-Length
         Content-Type: application/json
+        Server: go-ipfs/0.4.1-dev
         Trailer: X-Stream-Error
-        Transfer-Encoding: chunked
         X-Chunked-Output: 1
-        Date: Sat, 06 Feb 2016 22:46:50 GMT
+        Date: Wed, 13 Apr 2016 14:09:20 GMT
         Transfer-Encoding: chunked
         ```
 
@@ -2695,11 +2699,13 @@ FindProviders will return a list of peers who are able to provide the value requ
     + Headers
 
         ```
+        Access-Control-Allow-Headers: X-Stream-Output, X-Chunked-Output, X-Content-Length
+        Access-Control-Expose-Headers: X-Stream-Output, X-Chunked-Output, X-Content-Length
         Content-Type: application/json
+        Server: go-ipfs/0.4.1-dev
         Trailer: X-Stream-Error
-        Transfer-Encoding: chunked
         X-Chunked-Output: 1
-        Date: Sat, 06 Feb 2016 22:51:01 GMT
+        Date: Wed, 13 Apr 2016 14:10:51 GMT
         Transfer-Encoding: chunked
         ```
 
@@ -2983,11 +2989,13 @@ Find the closest peers to a given key by querying through the DHT.
     + Headers
 
         ```
+        Access-Control-Allow-Headers: X-Stream-Output, X-Chunked-Output, X-Content-Length
+        Access-Control-Expose-Headers: X-Stream-Output, X-Chunked-Output, X-Content-Length
         Content-Type: application/json
+        Server: go-ipfs/0.4.1-dev
         Trailer: X-Stream-Error
-        Transfer-Encoding: chunked
         X-Chunked-Output: 1
-        Date: Sat, 06 Feb 2016 22:59:25 GMT
+        Date: Wed, 13 Apr 2016 14:24:22 GMT
         Transfer-Encoding: chunked
         ```
 


### PR DESCRIPTION
Noted two main bugs:

~~\- [ ]  While `verbose` is specified in the HTTP API and is used in the HTTP request,
it returns no extra information in the ndjson response.~~
- [x] An invalid or empty key returns the same response as a normal one.
