### PR TITLE
Provide more detail around 'add' endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Apiary IPFS HTTP API description
 
 You can find the official API spec at the specs repo on:
 
-- https://github.com/ipfs/specs/tree/master/api
+- https://github.com/ipfs/specs/tree/master/public-api
 
 # Want to hack on IPFS?
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -27,16 +27,16 @@ MerkleDAG.
     + H (boolean, optional) - Hidden. Include files that are hidden.
     + s (boolean, optional) - Chunker. Chunking algorithm to use.
 
-+ Request Single File (multipart/form-data)
++ Request Single File (multipart/form-data; boundary=CUSTOM)
 
     #### Curl
 
-        curl -i -F "file=@test" "http://localhost:5001/api/v0/add"
+        curl -i -H "Content-Type: multipart/form-data; boundary=CUSTOM" -d $'--CUSTOM\r\nContent-Type: multipart/octet-stream\r\nContent-Disposition: file; filename="test"\r\n\r\nHello World!\n--CUSTOM--' "http://localhost:5001/api/v0/add"
 
     + Body
 
         ```
-        curl -i -F "file=@test" "http://localhost:5001/api/v0/add"
+        curl -i -H "Content-Type: multipart/form-data; boundary=CUSTOM" -d $'--CUSTOM\r\nContent-Type: multipart/octet-stream\r\nContent-Disposition: file; filename="test"\r\n\r\nHello World!\n--CUSTOM--' "http://localhost:5001/api/v0/add"
         ```
 
 + Response 200
@@ -65,7 +65,7 @@ MerkleDAG.
         ```
         {
             "Name":"test",
-            "Hash":"QmePw8gVcBMb8x6kAep6aMBAX23hCSk6iZW3i9VKkiFhu1"
+            "Hash":"QmfM2r8seH2GiRaC4esTjeraXEachRt8ZsSeGaWTPLyMoG"
         }
         ```
 


### PR DESCRIPTION
I had some trouble implementing calls to the 'add' endpoint, and figured it'd be worth documenting for other people. `curl -F` handles, and hides, a lot of multipart settings automatically, but a lot of HTTP libraries won't. I tried to replace the old command with a simple curl call that sets everything manually, hopefully it's more instructive.

I was having some trouble getting any version to compile with the Apiary client, so if there's something I can change let me know.

Also fixes a broken link in the Readme.
